### PR TITLE
Add `StatusIfPathsEmpty` feature

### DIFF
--- a/models.go
+++ b/models.go
@@ -28,6 +28,12 @@ type Source struct {
 	Labels                  []string                    `json:"labels"`
 	States                  []githubv4.PullRequestState `json:"states"`
 	StatusContext           string                      `json:"status_context"`
+	StatusIfPathsEmpty      Status                      `json:"status_if_paths_empty"`
+}
+
+type Status struct {
+	Context string `json:"context"`
+	Status  string `json:"status"`
 }
 
 // Validate the source configuration.


### PR DESCRIPTION
When there are no changed files found in the pull request for the specified
paths and ignored paths, we can optionally force the plugin to send a
github commit status.