### PR TITLE
Handle situation when `ignored_paths` and `paths` are set

### DIFF
--- a/check.go
+++ b/check.go
@@ -108,11 +108,29 @@ Loop:
 				}
 				wanted = append(wanted, w...)
 			}
+			// check if there are no files in the selected paths
 			if len(wanted) == 0 {
 				if err := sendEmptyPathStatus(p, request.Source, manager); err != nil {
 					return nil, err
 				}
 				continue Loop
+			}
+
+			// ...of the files in the selected paths, filter out those that are ignored
+			if len(request.Source.IgnorePaths) > 0 {
+				for _, pattern := range request.Source.IgnorePaths {
+					wanted, err = FilterIgnorePath(wanted, pattern)
+					if err != nil {
+						return nil, fmt.Errorf("ignore path match failed: %s", err)
+					}
+				}
+				// check if all the files in the selected paths are ignored
+				if len(wanted) == 0 {
+					if err := sendEmptyPathStatus(p, request.Source, manager); err != nil {
+						return nil, err
+					}
+					continue Loop
+				}
 			}
 		}
 

--- a/check_test.go
+++ b/check_test.go
@@ -315,7 +315,7 @@ func TestCheck(t *testing.T) {
 			},
 			version:                     resource.Version{},
 			pullRequests:                testPullRequests,
-			files:                       [][]string{{"some/path/x"}},
+			files:                       [][]string{{"some/path/x", "other/path/x"}},
 			expected:                    nil,
 			updateCommitStatusCallCount: 1,
 		},


### PR DESCRIPTION
Currently, the behaviour of `ignored_paths` applies to ALL the changed
files in the PR. You cannot apply the `ignored_files` filter to only
those files in the selected `paths`. This limits the usefulness of the
`ignored_paths`.

What we want is : 'Trigger the build when there are files in `paths` that
are not also in `ignored_paths`'